### PR TITLE
Added social.dinn.ca and added column for instance admin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Canadian-Mastodon-Instances
 A list of known Canadian Mastodon instances. Ordered alphabetically
 
-| Domain  | Goal |
-| ------------- | ------------- |
-| halifaxsocial.ca  | A place for Haligonians, past, present to hang out |
-| mstdn.ca  | A Mastodon instance run by Canadians for Canadians hosted in Canada.  |
-| oceanplayground.social | A Mastodon server for Atlantic Canada |
-| ottawa.place | Mastodon instance for residents of Ottawa, Gatineau, and surrounding regions |
-| thecanadian.social | Politics,sports,current events and laughs from Canada and across the fediverse. |
-| vancity.social | Metro Vancouver's home on the Fediverse! |
+| Domain  | Goal | Admin |
+| ------------- | ------------- | --------------- |
+| halifaxsocial.ca  | A place for Haligonians, past, present to hang out | `@petersmithca@halifaxsocial.ca` |
+| mstdn.ca  | A Mastodon instance run by Canadians for Canadians hosted in Canada.  | `@chad@mstdn.ca` |
+| oceanplayground.social | A Mastodon server for Atlantic Canada | `@matt@oceanplayground.social` |
+| ottawa.place | Mastodon instance for residents of Ottawa, Gatineau, and surrounding regions | `@adam@ottawa.place` |
+| social.dinn.ca | Personal instance for Steve, family, and a few friends | `@steve@social.dinn.ca` |
+| thecanadian.social | Politics,sports,current events and laughs from Canada and across the fediverse. | `@mike@thecanadian.social` |
+| vancity.social | Metro Vancouver's home on the Fediverse! | `@atomicpoet@vancity.social` |


### PR DESCRIPTION
I added my instance (`social.dinn.ca`) as well as a column for the instance admin's account.
I ended up formatting the instance admin account name as `code` because it was auto-detecting it as an email address, which, of course, it is not.